### PR TITLE
Add ByteSink

### DIFF
--- a/src/byte_sink.rs
+++ b/src/byte_sink.rs
@@ -1,0 +1,76 @@
+use std::io;
+
+use futures::{Async, Poll, Sink, StartSend, AsyncSink};
+
+use {AsyncWrite, AsyncRead};
+
+const BUFFER_SIZE: usize = 8 * 1024;
+
+/// A sink that consumes AsyncRead values, copying their contents to an
+/// AsyncWrite.
+pub struct ByteSink<W, R> {
+    write: W,
+    read: Option<R>,
+    write_cursor: usize,
+    read_cursor: usize,
+    buffer: [u8; BUFFER_SIZE],
+}
+
+/// Construct a sink that consumes AsyncReads, writing their entire contents to
+/// the supplied AsyncWrite.
+pub fn byte_sink<W, R>(write: W) -> ByteSink<W, R> {
+    ByteSink {
+        write: write,
+        read: None,
+        write_cursor: 0,
+        read_cursor: 0,
+        buffer: [0; BUFFER_SIZE],
+    }
+}
+
+impl<W: AsyncWrite, R: AsyncRead> Sink for ByteSink<W, R> {
+    type SinkItem = R;
+    type SinkError = io::Error;
+
+    fn start_send(&mut self, item: Self::SinkItem) -> StartSend<Self::SinkItem, Self::SinkError> {
+        if self.read.is_none() {
+            self.read = Some(item);
+            Ok(AsyncSink::Ready)
+        } else {
+            Ok(AsyncSink::NotReady(item))
+        }
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
+        loop {
+            if self.read.is_some() && self.write_cursor == 0 {
+                if let Async::NotReady = self.read.as_mut().unwrap().poll_read() {
+                    return Ok(Async::NotReady);
+                }
+
+                self.write_cursor = try_nb!(self.read.as_mut().unwrap().read(&mut self.buffer));
+                if self.write_cursor == 0 {
+                    self.read.take();
+                }
+            }
+
+            if self.write_cursor != 0 {
+                if let Async::NotReady = self.write.poll_write() {
+                    return Ok(Async::NotReady);
+                }
+            }
+
+            while self.read_cursor != self.write_cursor {
+                self.read_cursor += try_nb!(self.write.write(&self.buffer[self.read_cursor..self.write_cursor]));
+            }
+            
+            self.read_cursor = 0;
+            self.write_cursor = 0;
+
+            if self.read.is_none() {
+                try_nb!(self.write.flush());
+                return Ok(Async::Ready(()));
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ mod read_until;
 mod split;
 mod window;
 mod write_all;
+mod byte_sink;
 pub use self::copy::{copy, Copy};
 pub use self::flush::{flush, Flush};
 pub use self::frame::{EasyBuf, EasyBufMut, Framed, Codec};
@@ -63,6 +64,7 @@ pub use self::read_until::{read_until, ReadUntil};
 pub use self::split::{ReadHalf, WriteHalf};
 pub use self::window::Window;
 pub use self::write_all::{write_all, WriteAll};
+pub use self::byte_sink::{byte_sink, ByteSink};
 
 /// A trait for readable objects which operated in an asynchronous and
 /// futures-aware fashion.
@@ -187,5 +189,6 @@ pub trait AsyncWrite: io::Write {
 }
 
 impl AsyncRead for io::Repeat {}
+impl<T: AsRef<[u8]>> AsyncRead for io::Cursor<T> {}
 impl AsyncWrite for io::Sink {}
 impl<T: AsyncRead> AsyncRead for io::Take<T> {}


### PR DESCRIPTION
This provides similar functionality to `copy`, but with an API that may be more convenient for some cases. For example, if you want to transmit a series of messages whose complete encoded form might be unreasonable large (e.g. if it includes the contents of a file or another arbitrarily-sized stream), you could implement an `AsyncRead` interface that extracts or computes it piecewise.