### PR TITLE
Restore generic coding errors

### DIFF
--- a/src/framed.rs
+++ b/src/framed.rs
@@ -32,7 +32,7 @@ impl<T, U> Stream for Framed<T, U>
           U: Decoder,
 {
     type Item = U::Item;
-    type Error = io::Error;
+    type Error = U::Error;
 
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
         self.inner.poll()
@@ -106,12 +106,13 @@ impl<T: AsyncWrite, U> AsyncWrite for Fuse<T, U> {
 
 impl<T, U: Decoder> Decoder for Fuse<T, U> {
     type Item = U::Item;
+    type Error = U::Error;
 
-    fn decode(&mut self, buffer: &mut BytesMut) -> io::Result<Option<Self::Item>> {
+    fn decode(&mut self, buffer: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         self.1.decode(buffer)
     }
 
-    fn decode_eof(&mut self, buffer: &mut BytesMut) -> io::Result<Option<Self::Item>> {
+    fn decode_eof(&mut self, buffer: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         self.1.decode_eof(buffer)
     }
 }

--- a/src/framed.rs
+++ b/src/framed.rs
@@ -42,9 +42,10 @@ impl<T, U> Stream for Framed<T, U>
 impl<T, U> Sink for Framed<T, U>
     where T: AsyncWrite,
           U: Encoder,
+          U::Error: From<io::Error>,
 {
     type SinkItem = U::Item;
-    type SinkError = io::Error;
+    type SinkError = U::Error;
 
     fn start_send(&mut self,
                   item: Self::SinkItem)
@@ -119,8 +120,9 @@ impl<T, U: Decoder> Decoder for Fuse<T, U> {
 
 impl<T, U: Encoder> Encoder for Fuse<T, U> {
     type Item = U::Item;
+    type Error = U::Error;
 
-    fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> io::Result<()> {
+    fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
         self.1.encode(item, dst)
     }
 }

--- a/src/framed_write.rs
+++ b/src/framed_write.rs
@@ -211,12 +211,13 @@ impl<T> Sink for FramedWrite2<T>
 
 impl<T: Decoder> Decoder for FramedWrite2<T> {
     type Item = T::Item;
+    type Error = T::Error;
 
-    fn decode(&mut self, src: &mut BytesMut) -> io::Result<Option<T::Item>> {
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<T::Item>, T::Error> {
         self.inner.decode(src)
     }
 
-    fn decode_eof(&mut self, src: &mut BytesMut) -> io::Result<Option<T::Item>> {
+    fn decode_eof(&mut self, src: &mut BytesMut) -> Result<Option<T::Item>, T::Error> {
         self.inner.decode_eof(src)
     }
 }

--- a/src/length_delimited.rs
+++ b/src/length_delimited.rs
@@ -319,6 +319,7 @@ impl Decoder {
 
 impl codec::Decoder for Decoder {
     type Item = BytesMut;
+    type Error = io::Error;
 
     fn decode(&mut self, src: &mut BytesMut) -> io::Result<Option<BytesMut>> {
         let n = match self.state {

--- a/tests/framed_read.rs
+++ b/tests/framed_read.rs
@@ -24,6 +24,7 @@ struct U32Decoder;
 
 impl Decoder for U32Decoder {
     type Item = u32;
+    type Error = io::Error;
 
     fn decode(&mut self, buf: &mut BytesMut) -> io::Result<Option<u32>> {
         if buf.len() < 4 {
@@ -140,6 +141,7 @@ fn huge_size() {
 
     impl Decoder for BigDecoder {
         type Item = u32;
+        type Error = io::Error;
 
         fn decode(&mut self, buf: &mut BytesMut) -> io::Result<Option<u32>> {
             if buf.len() < 32 * 1024 {
@@ -166,6 +168,7 @@ fn multi_frames_on_eof() {
 
     impl Decoder for MyDecoder {
         type Item = u32;
+        type Error = io::Error;
 
         fn decode(&mut self, _buf: &mut BytesMut) -> io::Result<Option<u32>> {
             unreachable!();

--- a/tests/framed_write.rs
+++ b/tests/framed_write.rs
@@ -23,6 +23,7 @@ struct U32Encoder;
 
 impl Encoder for U32Encoder {
     type Item = u32;
+    type Error = io::Error;
 
     fn encode(&mut self, item: u32, dst: &mut BytesMut) -> io::Result<()> {
         // Reserve space


### PR DESCRIPTION
This reverts commit cddbdb349cc597b2ab378f3ae26ebeeb7747ecab.

Fixes #7 and https://github.com/tokio-rs/tokio-core/issues/146

I attempted to preserve the doc changes that had been made since.

I was tempted to also revert @carllerche's addition of an error condition to `Encoder` entirely, since IMO futures like `stream::Forward` should only fail when framing is irrecoverable and I can't imagine why that would occur in an encoding stage, but ultimately decided it was unclear enough to consider separately.