### PR TITLE
Handle extra-large frames by allocating more space

### DIFF
--- a/src/framed_read.rs
+++ b/src/framed_read.rs
@@ -213,7 +213,10 @@ impl<T> Stream for FramedRead2<T>
 
             assert!(!self.eof);
 
-            // Otherwise, try to read more data and try again
+            // Otherwise, try to read more data and try again. Make sure we've
+            // got room for at least one byte to read to ensure that we don't
+            // get a spurious 0 that looks like EF
+            self.buffer.reserve(1);
             if 0 == try_ready!(self.inner.read_buf(&mut self.buffer)) {
                 self.eof = true;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,6 +190,12 @@ impl<'a, T: ?Sized + AsyncRead> AsyncRead for &'a mut T {
     }
 }
 
+impl<'a> AsyncRead for &'a [u8] {
+    unsafe fn prepare_uninitialized_buffer(&self, _buf: &mut [u8]) -> bool {
+        false
+    }
+}
+
 /// A trait for writable objects which operated in an asynchronous and
 /// futures-aware fashion.
 ///


### PR DESCRIPTION
Ensure that whenever we issue an underlying read we have space for at least one
byte to ensure that we don't misinterpret 0 == eof when there's actually no
space left in our internal buffer.

Closes #8