### PR TITLE
Add a required AsyncWrite::shutdown method

### DIFF
--- a/src/framed.rs
+++ b/src/framed.rs
@@ -82,6 +82,9 @@ impl<T: Write, U> Write for Fuse<T, U> {
 }
 
 impl<T: AsyncWrite, U> AsyncWrite for Fuse<T, U> {
+    fn shutdown(&mut self) -> Poll<(), io::Error> {
+        self.0.shutdown()
+    }
 }
 
 impl<T, U: Decoder> Decoder for Fuse<T, U> {

--- a/src/io.rs
+++ b/src/io.rs
@@ -16,6 +16,7 @@ pub use read::{read, Read};
 pub use read_exact::{read_exact, ReadExact};
 pub use read_to_end::{read_to_end, ReadToEnd};
 pub use read_until::{read_until, ReadUntil};
+pub use shutdown::{shutdown, Shutdown};
 pub use split::{ReadHalf, WriteHalf};
 pub use window::Window;
 pub use write_all::{write_all, WriteAll};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ mod read;
 mod read_exact;
 mod read_to_end;
 mod read_until;
+mod shutdown;
 mod split;
 mod window;
 mod write_all;
@@ -193,10 +194,10 @@ impl<'a, T: ?Sized + AsyncRead> AsyncRead for &'a mut T {
 /// A trait for writable objects which operated in an asynchronous and
 /// futures-aware fashion.
 ///
-/// This trait inherits from `io::Write` and indicates as a marker that an I/O
-/// object is **nonblocking**, meaning that it will return an error instead of
-/// blocking when bytes are written. Specifically this means that the `write`
-/// function for traits that implement this type can have a few return values:
+/// This trait inherits from `io::Write` and indicates that an I/O object is
+/// **nonblocking**, meaning that it will return an error instead of blocking
+/// when bytes are written. Specifically this means that the `write` function
+/// for traits that implement this type can have a few return values:
 ///
 /// * `Ok(n)` means that `n` bytes of data was immediately written .
 /// * `Err(e) if e.kind() == ErrorKind::WouldBlock` means that no data was
@@ -211,6 +212,52 @@ impl<'a, T: ?Sized + AsyncRead> AsyncRead for &'a mut T {
 /// This trait importantly means that the `write` method only works in the
 /// context of a future's task. The object may panic if used outside of a task.
 pub trait AsyncWrite: std_io::Write {
+    /// Initiates or attempts to shut down this writer, returning success when
+    /// the I/O connection has completely shut down.
+    ///
+    /// This method is intended to be used for asynchronous shutdown of I/O
+    /// connections. For example this is suitable for implementing shutdown of a
+    /// TLS connection or calling `TcpStream::shutdown` on a proxied connection.
+    ///
+    /// This `shutdown` method is required by implementors of the
+    /// `AsyncWrite` trait. Wrappers typically just want to proxy this call
+    /// through to the wrapped type, and base types will typically implement
+    /// shutdown logic here or just return `Ok(().into())`.
+    ///
+    /// # Return value
+    ///
+    /// This function returns a `Poll<(), io::Error>` classified as such:
+    ///
+    /// * `Ok(Async::Ready(()))` - indicates that the connection was
+    ///   successfully shut down and is now safe to deallocate/drop/close
+    ///   resources associated with it. This method means that the current task
+    ///   will no longer receive any notifications due to this method and the
+    ///   I/O object itself is likely no longer usable.
+    ///
+    /// * `Ok(Async::NotReady)` - indicates that shutdown is initiated but could
+    ///   not complete just yet. This may mean that more I/O needs to happen to
+    ///   continue this shutdown operation. The current task is scheduled to
+    ///   receive a notification when it's otherwise ready to continue the
+    ///   shutdown operation. When woken up this method should be called again.
+    ///
+    /// * `Err(e)` - indicates a fatal error has happened with shutdown,
+    ///   indicating that the shutdown operation did not complete successfully.
+    ///   This typically means that the I/O object is no longer usable.
+    ///
+    /// # Errors
+    ///
+    /// This function can return normal I/O errors through `Err`, described
+    /// above. Additionally this method may also render the underlying
+    /// `Write::write` method no longer usable (e.g. will return errors in the
+    /// future). It's recommended that once `shutdown` is called the
+    /// `write` method is no longer called.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if not called within the context of a future's
+    /// task.
+    fn shutdown(&mut self) -> Poll<(), std_io::Error>;
+
     /// Write a `Buf` into this value, returning how many bytes were written.
     ///
     /// Note that this method will advance the `buf` provided automatically by
@@ -227,8 +274,14 @@ pub trait AsyncWrite: std_io::Write {
 }
 
 impl<T: ?Sized + AsyncWrite> AsyncWrite for Box<T> {
+    fn shutdown(&mut self) -> Poll<(), std_io::Error> {
+        (**self).shutdown()
+    }
 }
 impl<'a, T: ?Sized + AsyncWrite> AsyncWrite for &'a mut T {
+    fn shutdown(&mut self) -> Poll<(), std_io::Error> {
+        (**self).shutdown()
+    }
 }
 
 impl AsyncRead for std_io::Repeat {
@@ -238,6 +291,9 @@ impl AsyncRead for std_io::Repeat {
 }
 
 impl AsyncWrite for std_io::Sink {
+    fn shutdown(&mut self) -> Poll<(), std_io::Error> {
+        Ok(().into())
+    }
 }
 
 // TODO: Implement `prepare_uninitialized_buffer` for `io::Take`.

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -1,0 +1,43 @@
+use std::io;
+
+use futures::{Poll, Future, Async};
+
+use AsyncWrite;
+
+/// A future used to fully shutdown an I/O object.
+///
+/// Resolves to the underlying I/O object once the shutdown operation is
+/// complete.
+///
+/// Created by the [`shutdown`] function.
+///
+/// [`shutdown`]: fn.shutdown.html
+pub struct Shutdown<A> {
+    a: Option<A>,
+}
+
+/// Creates a future which will entirely shutdown an I/O object and then yield
+/// the object itself.
+///
+/// This function will consume the object provided if an error happens, and
+/// otherwise it will repeatedly call `shutdown` until it sees `Ok(())`,
+/// scheduling a retry if `WouldBlock` is seen along the way.
+pub fn shutdown<A>(a: A) -> Shutdown<A>
+    where A: AsyncWrite,
+{
+    Shutdown {
+        a: Some(a),
+    }
+}
+
+impl<A> Future for Shutdown<A>
+    where A: AsyncWrite,
+{
+    type Item = A;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<A, io::Error> {
+        try_nb!(self.a.as_mut().unwrap().shutdown());
+        Ok(Async::Ready(self.a.take().unwrap()))
+    }
+}

--- a/src/split.rs
+++ b/src/split.rs
@@ -1,6 +1,6 @@
 use std::io::{self, Read, Write};
 
-use futures::Async;
+use futures::{Async, Poll};
 use futures::sync::BiLock;
 
 use {AsyncRead, AsyncWrite};
@@ -53,4 +53,10 @@ impl<T: AsyncWrite> Write for WriteHalf<T> {
 }
 
 impl<T: AsyncWrite> AsyncWrite for WriteHalf<T> {
+    fn shutdown(&mut self) -> Poll<(), io::Error> {
+        match self.handle.poll_lock() {
+            Async::Ready(mut l) => l.shutdown(),
+            Async::NotReady => Err(would_block()),
+        }
+    }
 }

--- a/tests/framed_write.rs
+++ b/tests/framed_write.rs
@@ -5,7 +5,7 @@ extern crate futures;
 use tokio_io::AsyncWrite;
 use tokio_io::codec::{Encoder, FramedWrite};
 
-use futures::{Sink};
+use futures::{Sink, Poll};
 use bytes::{BytesMut, BufMut, BigEndian};
 
 use std::io::{self, Write};
@@ -126,4 +126,7 @@ impl Write for Mock {
 }
 
 impl AsyncWrite for Mock {
+    fn shutdown(&mut self) -> Poll<(), io::Error> {
+        Ok(().into())
+    }
 }


### PR DESCRIPTION
This commit adds a method for `AsyncWrite` streams to hook into shutdown
semantics and otherwise perform clean shutdowns and such. A method
`AsyncWrite::shutdown` is added to embody these shutdown semantics,
returning `Ready` when it's done and `NotReady` if it's scheduled to do more
work. Currently it's also documented as basically invalidating the rest of the
I/O object, only allowing future `shutdown` method calls.

Additionally a `io::shutdown` future was added to shut down in a future-style
fashion.

Closes #11